### PR TITLE
PF-26: Update project tabs scroll button

### DIFF
--- a/components/sections/projects/chillyDog/tabs/tabs.tsx
+++ b/components/sections/projects/chillyDog/tabs/tabs.tsx
@@ -34,8 +34,9 @@ export const ChillyDogTabs = (): ReactElement => {
           value={value}
           onChange={handleChange}
           variant='scrollable'
-          scrollButtons='auto'
-          aria-label='basic tabs example'
+          aria-label='Chilly Dog Tabs'
+          scrollButtons
+          allowScrollButtonsMobile
         >
           <Tab label='About' {...a11yProps(0)} sx={customTabStyle} />
           <Tab label='Stack' {...a11yProps(1)} sx={customTabStyle} />

--- a/components/sections/projects/storybook/tabs/tabs.tsx
+++ b/components/sections/projects/storybook/tabs/tabs.tsx
@@ -31,8 +31,9 @@ export const StorybookTabs = (): ReactElement => {
           value={value}
           onChange={handleChange}
           variant='scrollable'
-          scrollButtons='auto'
-          aria-label='basic tabs example'
+          scrollButtons
+          allowScrollButtonsMobile
+          aria-label='storybook tabs'
         >
           <Tab label='About' {...a11yProps(0)} sx={customTabStyle} />
           <Tab label='Stack' {...a11yProps(1)} sx={customTabStyle} />


### PR DESCRIPTION
## Pull Request

**Description:**

- Scroll button added for project tabs in mobile screen

**Checklist:**

- [x] I have tested the changes locally.

**Screenshots (if applicable):**
<img width="413" alt="Screen Shot 2024-02-19 at 12 22 45 AM" src="https://github.com/Seolcita/portfolio-sk/assets/83251839/2aaa8ff7-fc03-484e-9990-b3bc80df3c15">


**Future Works:**
- N/A